### PR TITLE
Add babel presets to webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,10 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        exclude: /node_modules/
+        exclude: /node_modules/,
+        query: {
+          presets: ['es2015', 'stage-1']
+        }
       },
       {
         test: /\.json$/,


### PR DESCRIPTION
Nice simple starter, thanks! 
I just noticed that I couldn't use ES6 without adding the `presets` query to the babel loader.

Alternatively, you could add a `.babelrc` file, but I figured this was easier.
